### PR TITLE
Add new controls in constant/ABLProperties for writing source terms

### DIFF
--- a/exampleCases/example.ABL.flatTerrain.neutral/setUp
+++ b/exampleCases/example.ABL.flatTerrain.neutral/setUp
@@ -47,9 +47,10 @@ decompOrder          (6 6 6);                     // Order of the decomposition 
 // Planar averaging and source term statistics options.
 // * Used by the planarAveraging function object in 'system/sampling/planarAveraging'
 
-statisticsFrequency  5;                           // Frequency in time steps of statistics gathering.
-
-
+writeSource                 true;
+writeSourceInterval         1;
+writePlanarAverage          true;
+writePlanarAverageInterval  1;
 
 
 

--- a/exampleCases/example.ABL.flatTerrain.neutral/system/sampling/planarAveraging
+++ b/exampleCases/example.ABL.flatTerrain.neutral/system/sampling/planarAveraging
@@ -4,9 +4,9 @@
           #include            "../../setUp"
           type                 planarAveraging;
           functionObjectLibs   ("libSOWFAfieldFunctionObjects.so");
-          enabled              true;
+          enabled              $writePlanarAverage;
           writeControl         timeStep;
-          writeInterval        $statisticsFrequency;
+          writeInterval        $writePlanarAverageInterval;
           fields
           (
               U

--- a/src/ABLForcing/ABLProperties
+++ b/src/ABLForcing/ABLProperties
@@ -120,9 +120,9 @@ upperSponge
 }
 
 
-// Statistics gathering input
-statisticsOn              $statisticsOn;
-statisticsFrequency       $statisticsFrequency;
+// Write out postProcessing/sourceHistory
+writeSource             $writeSource;
+writeSourceInterval     $writeSourceInterval;
 
 
 // ************************************************************************* //

--- a/src/ABLForcing/drivingForce/drivingForce.C
+++ b/src/ABLForcing/drivingForce/drivingForce.C
@@ -213,9 +213,9 @@ void Foam::drivingForce<Type>::writeSourceHistory_
     // Write the source information.
     if (Pstream::master())
     {
-        if (statisticsOn_)
+        if (writeSource_)
         {
-            if (runTime_.timeIndex() % statisticsFreq_ == 0)
+            if (runTime_.timeIndex() % writeSourceInterval_ == 0)
             {
                 sourceHistoryFile_() << runTime_.timeName() << " " << runTime_.deltaT().value() << " " << source << endl;
             }
@@ -233,9 +233,9 @@ void Foam::drivingForce<Type>::writeErrorHistory_
     // Write the error information.
     if (Pstream::master())
     {
-        if (statisticsOn_)
+        if (writeSource_)
         {
-            if (runTime_.timeIndex() % statisticsFreq_ == 0)
+            if (runTime_.timeIndex() % writeSourceInterval_ == 0)
             {
                 errorHistoryFile_() << runTime_.timeName() << " " << runTime_.deltaT().value() << " " << error << endl;
             }
@@ -253,9 +253,9 @@ void Foam::drivingForce<Type>::writeSourceHistory_
     // Write the column of source information.
     if (Pstream::master())
     {
-        if (statisticsOn_)
+        if (writeSource_)
         {
-            if (runTime_.timeIndex() % statisticsFreq_ == 0)
+            if (runTime_.timeIndex() % writeSourceInterval_ == 0)
             {
                 sourceHistoryFile_() << runTime_.timeName() << " " << runTime_.deltaT().value();
 
@@ -282,7 +282,7 @@ void Foam::drivingForce<Type>::writeErrorHistory_
     {
         if (writeError_)
         {
-            if (runTime_.timeIndex() % statisticsFreq_ == 0)
+            if (runTime_.timeIndex() % writeSourceInterval_ == 0)
             {
                 errorHistoryFile_() << runTime_.timeName() << " " << runTime_.deltaT().value();
 
@@ -487,12 +487,10 @@ void Foam::drivingForce<Type>::readInputData_()
     // PROPERTIES CONCERNING GATHERING STATISTICS
 
     // Gather/write statistics?
-    bool statisticsOn(ABLProperties.lookupOrDefault<bool>("statisticsOn",false));
-    statisticsOn_ = statisticsOn;
+    writeSource_ = ABLProperties.lookupOrDefault<bool>("writeSource",true);
 
     // Statistics gathering/writing frequency?
-    int statisticsFreq(int(readScalar(ABLProperties.lookup("statisticsFrequency"))));
-    statisticsFreq_ = statisticsFreq;
+    writeSourceInterval_ = ABLProperties.lookupOrDefault<int>("writeSourceInterval",1);
 }
 
 

--- a/src/ABLForcing/drivingForce/drivingForce.H
+++ b/src/ABLForcing/drivingForce/drivingForce.H
@@ -77,8 +77,8 @@ Usage
         regSmoothing                | Regression smoothing      | no        | true
         regOrder                    | Regression order          | no        | 1
         weightsTable                | Table with weights        | no        |
-        statisticsOn                | Write out source profile  | no        | false
-        statisticsFrequency         | Writing frequency         | yes       |
+        writeSource                 | Write out source profile  | no        | true
+        writeSourceFrequency        | Writing frequency         | no        | 1
 
 SourceFiles
     drivingForce.C
@@ -190,11 +190,11 @@ class drivingForce
         //- Write error profile?
         bool writeError_;
 
-        //- Gather/write statistics?
-        bool statisticsOn_;
+        //- Gather/write source profile?
+        bool writeSource_;
 
-        //- Statistics gathering/writing frequency?
-        int statisticsFreq_;
+        //- Source writing frequency?
+        int writeSourceInterval_;
 
 
     // Private Member Functions


### PR DESCRIPTION
Added:
- writeSource (instead of statisticsOn)
- writeSourceInterval (instead of statisticsFrequency)

Also, add additional options in setUp for planarAveraging output:
- writePlanarAverage
- writePlanarAverageInterval
referenced in system/sampling/planarAveraging