### PR TITLE
Utility to write cell centers

### DIFF
--- a/applications/utilities/writeCellCenters/Make/files
+++ b/applications/utilities/writeCellCenters/Make/files
@@ -1,0 +1,3 @@
+writeCellCenters.C
+
+EXE = $(SOWFA_DIR)/applications/bin/$(WM_OPTIONS)/writeCellCenters

--- a/applications/utilities/writeCellCenters/Make/options
+++ b/applications/utilities/writeCellCenters/Make/options
@@ -1,0 +1,5 @@
+EXE_INC = \
+    -I$(LIB_SRC)/meshTools/lnInclude
+
+EXE_LIBS = \
+    -lmeshTools

--- a/applications/utilities/writeCellCenters/writeCellCenters.C
+++ b/applications/utilities/writeCellCenters/writeCellCenters.C
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
 
         fileName outputFile
         (
-            mesh.time().path()/"cellCenters"
+            mesh.time().path()/"constant"/"cellCenters"
         );
         Info<< "Writing mesh cell centers to " << outputFile << endl;
         OFstream os(outputFile);
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
 
         fileName outputCSVFile
         (
-            mesh.time().path()/"cellCenters.csv"
+            mesh.time().path()/"constant"/"cellCenters.csv"
         );
         Info<< "Writing mesh cell centers to " << outputCSVFile << endl;
         OFstream csv(outputCSVFile);

--- a/applications/utilities/writeCellCenters/writeCellCenters.C
+++ b/applications/utilities/writeCellCenters/writeCellCenters.C
@@ -71,6 +71,7 @@ int main(int argc, char *argv[])
         );
         Info<< "Writing mesh cell centers to " << outputCSVFile << endl;
         OFstream csv(outputCSVFile);
+        csv << "x,y,z" << nl;
         forAll(mesh.cellCentres(), cellI)
         {
             vector cc = mesh.cellCentres()[cellI];

--- a/applications/utilities/writeCellCenters/writeCellCenters.C
+++ b/applications/utilities/writeCellCenters/writeCellCenters.C
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2018 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Application
+    writeCellCenters
+
+Description
+    Helper utility to output cell center locations for generating complex
+    initial fields.
+
+\*---------------------------------------------------------------------------*/
+
+#include "argList.H"
+#include "timeSelector.H"
+#include "Time.H"
+#include "polyMesh.H"
+#include "OFstream.H"
+
+using namespace Foam;
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+int main(int argc, char *argv[])
+{
+    timeSelector::addOptions();
+    #include "addRegionOption.H"
+    #include "setRootCase.H"
+    #include "createTime.H"
+    instantList timeDirs = timeSelector::select0(runTime, args);
+
+    #include "createNamedPolyMesh.H"
+
+    forAll(timeDirs, timeI)
+    {
+        runTime.setTime(timeDirs[timeI], timeI);
+
+        Info<< "Time = " << runTime.timeName() << endl;
+
+        fileName outputFile
+        (
+            mesh.time().path()/"cellCenters"
+        );
+        Info<< "Writing mesh cell centers to " << outputFile << endl;
+        OFstream os(outputFile);
+        os.format("binary");
+        os << mesh.cellCentres();
+
+        fileName outputCSVFile
+        (
+            mesh.time().path()/"cellCenters.csv"
+        );
+        Info<< "Writing mesh cell centers to " << outputCSVFile << endl;
+        OFstream csv(outputCSVFile);
+        forAll(mesh.cellCentres(), cellI)
+        {
+            vector cc = mesh.cellCentres()[cellI];
+            csv << cc.x() << "," << cc.y() << "," << cc.z() << nl;
+        }
+
+        Info<< nl << endl;
+    }
+
+    Info<< "End\n" << endl;
+
+    return 0;
+}
+
+
+// ************************************************************************* //


### PR DESCRIPTION
Running this utility in your case directory will generate `constant/cellCenters` and `constant/cellCenters.csv`, a list of cell center locations that are not explicitly saved as part of the polyMesh definition.