### PR TITLE
Vertical filter on lateral damping layers

### DIFF
--- a/src/ABLForcing/ABLProperties
+++ b/src/ABLForcing/ABLProperties
@@ -1,9 +1,9 @@
-/*---------------------------------------------------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  2.4.x                                 |
-|   \\  /    A nd           | Web:      http://www.openfoam.org               |
-|    \\/     M anipulation  |                                                 |
+/*--------------------------------*- C++ -*----------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Version:  6
+     \\/     M anipulation  |
 \*---------------------------------------------------------------------------*/
 
 FoamFile
@@ -106,32 +106,65 @@ perturbationPressureType  "rhokSplit";              // Options for defining the 
 // Sponge layer parameters.
 spongeList
 {
-    upperSponge
+    westSponge
+    {
+        type             "Rayleigh";                // Type of sponge layer: "none" (Default), "Rayleigh" or "viscous".
+        startLocation    0.0;                       // Start location of the sponge layer (m).
+        width            5000.0;                    // Width of the sponge layer (m).
+        viscosityMax     0.01;                      // Maximum viscosity, dimensions depend on type of damping:
+                                                    // Rayleigh (1/s),  viscous  (m^2/s)
+        coordIndex       0;                         // Coordinate index: 0, 1 or 2 corresponding to yz, xz or xy slab.
+        direction        "stepDown";                // Shape of damping function: "stepUp" increases smoothly from 0 to 1 in the
+                                                    // specified coordinate direction, "stepDown" decreases in the coordinate direction.
+        dampingComp      "horizontal";              // Components to be damped: "horizontal" for x and y, or "vertical" for z
+                                                    //    if "horizontal" and "Rayleigh", Ux and Uy need to be specified  
+        Ux               8.0;                       // Sponge layer reference velocity in x direction (m/s).
+        Uy               0.0;                       // Sponge layer reference velocity in y direction (m/s).
+
+        verticalFilter   true;
+        vertStartLoc     1000;
+        cosThickness     100;
+        useWallDistZ     true;
+    }
+    northSponge
     {
         type             "Rayleigh";                // Type of sponge layer: "none" (Default), "Rayleigh" or "viscous".
         startLocation    10000.0;                   // Start location of the sponge layer (m).
         width            5000.0;                    // Width of the sponge layer (m).
         viscosityMax     0.01;                      // Maximum viscosity, dimensions depend on type of damping:
                                                     // Rayleigh (1/s),  viscous  (m^2/s)
-        coordIndex       2;                         // Coordinate index: 0, 1 or 2 corresponding to yz, xz or xy slab.
+        coordIndex       1;                         // Coordinate index: 0, 1 or 2 corresponding to yz, xz or xy slab.
         direction        "stepUp";                  // Shape of damping function: "stepUp" increases smoothly from 0 to 1 in the
                                                     // specified coordinate direction, "stepDown" decreases in the coordinate direction.
-        dampingDir       "horizontal";              // Components to be damped: "horizontal" for x and y, or "vertical" for z
+        dampingComp      "horizontal";              // Components to be damped: "horizontal" for x and y, or "vertical" for z
                                                     //    if "horizontal" and "Rayleigh", Ux and Uy need to be specified  
-        Ux               10.0;                      // Sponge layer reference velocity in x direction (m/s).
+        Ux               8.0;                       // Sponge layer reference velocity in x direction (m/s).
         Uy               0.0;                       // Sponge layer reference velocity in y direction (m/s).
+
+        verticalFilter   true;
+        vertStartLoc     1000;
+        cosThickness     100;
+        useWallDistZ     true;
     }
-    eastSponge
+    southSponge
     {
-        type             "Rayleigh";
-        startLocation    10000.0;   
-        width            5000.0;    
-        Ux               10.0;      
-        Uy               0.0;       
-        viscosityMax     0.01;      
-        coordIndex       0;         
-        direction        "stepUp";  
-        dampingDir       "vertical";
+        type             "Rayleigh";                // Type of sponge layer: "none" (Default), "Rayleigh" or "viscous".
+        startLocation    0.0;                       // Start location of the sponge layer (m).
+        width            5000.0;                    // Width of the sponge layer (m).
+        viscosityMax     0.01;                      // Maximum viscosity, dimensions depend on type of damping:
+                                                    // Rayleigh (1/s),  viscous  (m^2/s)
+        coordIndex       1;                         // Coordinate index: 0, 1 or 2 corresponding to yz, xz or xy slab.
+        direction        "stepDown";                // Shape of damping function: "stepUp" increases smoothly from 0 to 1 in the
+                                                    // specified coordinate direction, "stepDown" decreases in the coordinate direction.
+        dampingComp      "horizontal";              // Components to be damped: "horizontal" for x and y, or "vertical" for z
+                                                    //    if "horizontal" and "Rayleigh", Ux and Uy need to be specified  
+        Ux               8.0;                       // Sponge layer reference velocity in x direction (m/s).
+        Uy               0.0;                       // Sponge layer reference velocity in y direction (m/s).
+
+        verticalFilter   true;
+        vertStartLoc     1000;
+        cosThickness     100;
+        useWallDistZ     true;
     }
 }
 

--- a/src/ABLForcing/spongeLayer/spongeLayer.H
+++ b/src/ABLForcing/spongeLayer/spongeLayer.H
@@ -43,6 +43,7 @@ SourceFiles
 
 #include "fvCFD.H"
 #include "IOdictionary.H"
+#include "wallDist.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -101,7 +102,11 @@ class spongeLayer
         word dampingComp_;
         scalar Ux_;
         scalar Uy_;
-
+        //- Vertical filter parameters
+        bool verticalFilter_;
+        scalar vertStartLoc_;
+        scalar cosThickness_;
+        bool useWallDistZ_;
 
 
 


### PR DESCRIPTION
Extension of the sponge layer class to deal with vertical damping on layers present on the side boundaries of the domain. The idea is that the regular damping layers may potentially modify (dampen) a turbulent flow used as a boundary data input. So a height-dependent filter is superimposed on the side damping layers. The term "height filter" is used to avoid confusion with "vertical damping" (which means the vertical component of the velocity is damped).

The main use-case as of right now is to add such height around the capping inversion. With that, gravity layers can be properly damped, while letting turbulent inflow come into the domain undamped. Example dictionary is provided in `src/ABLForcing/ABLProperties`

How it works:
- The height filter imposes a cosine where it gets rid of any damping below the `vertStartLocation` and leave any damping above `vertStartLocation`+`cosThickness` untouched. It acts simply as filter on the original layer's parameters. With that, the `width`, and `viscosityMax` will be followed, as well as the `dampingComp`. 
- The height damping will only be activated if `coordIndex` is either 0 (yz slab) or 1 (xy slab).

How to use it:
- Specify `verticalFilter` to `true`
- Specify `vertStartLocation`. This is the start of the cosine region, which means no damping below `vertStartLocation`
- Specify `cosThickness`. This is the thickness of the smooth cosine vertical transition.
- Set `useWallDistZ` if distance from terrain is to be used as height. If `true`, the user also needs to set `wallDist` information on `system/fvSchemes`


Known bug:
- The different layers are having the vertical filter set at slightly different heights, despite the same settings.
Example of the bug on a flat domain (The transition is supposed to be contained within the shaded box):
![Screen Shot 2020-10-12 at 12 16 53 PM](https://user-images.githubusercontent.com/13243358/95778249-f6c11f00-0c84-11eb-9fdf-9735a4799555.png)
And on a complex terrain (with `useWallDistZ` set to `true`):
![Screen Shot 2020-10-12 at 10 56 39 AM](https://user-images.githubusercontent.com/13243358/95778282-03de0e00-0c85-11eb-8b52-6683f91992c3.png)
