### PR TITLE
Simple fix on `south` boundary sponge layer specification

### DIFF
--- a/exampleCases/tut.ABLflatTerrain.precursor/0.original/qwall.wrf
+++ b/exampleCases/tut.ABLflatTerrain.precursor/0.original/qwall.wrf
@@ -26,6 +26,16 @@ boundaryField
 {
     lower
     {
+        // ---------------------------------------------
+        // Use `uniformFixedValue` if giving a q history
+        //  type             uniformFixedValue;
+        //  uniformValue     table
+        //  (
+        //      #include "../constant/drivingData/qwallTable"
+        //  );
+
+        // -----------------------------------------------------------
+        // Use `specifiedSurfaceTemperature` if giving a theta history
         type            specifiedSurfaceTemperature;
         TSurface        table
         (

--- a/exampleCases/tut.ABLflatTerrain.precursor/system/fvSolution
+++ b/exampleCases/tut.ABLflatTerrain.precursor/system/fvSolution
@@ -88,7 +88,7 @@ PIMPLE
     nCorrectors              3;
     nNonOrthogonalCorrectors 0;
     activatePressureRefCell  false;    // default: true
-    pRefPoint                (#calc "($xMax + $xMin)/2+0.001"    #calc "($yMax + $yMin)/2+0.001"    #calc "$zMin+85.001");
+    pRefPoint                (#calc "($xMax + $xMin)/2+0.001"    #calc "($yMax + $yMin)/2+0.001"    #calc "$zMax-100.001");
     pRefValue                0;
 }
 

--- a/exampleCases/tut.ABLflatTerrain.run/1_preprocess
+++ b/exampleCases/tut.ABLflatTerrain.run/1_preprocess
@@ -24,6 +24,7 @@ solver=superDeliciousVanilla
 refLoc=floating                 # floating, ground.
 coupled=precursor               # precursor,WRFint,WRFbd. WRF-coupled uses the PAT method
 interp=linearupwind             # midpoint, linearupwind. divSchmes midpoints needed for gravity waves
+# If coupled=WRF*, modify 0.forWRFcoupled/qwall.wrf with the appropriate BC (q or T given)
 # **************************************************************************************************** #
 
 # **************************************** PERFORM SOME CHECKS *************************************** #
@@ -121,7 +122,7 @@ decomposePar -cellDist -force > log.1.decomposePar 2>&1
 # Perform global refinements after decomposePar, avoiding load unbalance
 refineMeshGlobal $nGlobalRefs
 
-# Change the boundary conditions from cyclic everywhere to TVMIO. See readme file
+# Change the boundary conditions from cyclic everywhere to TVMIO, unless WRFint. See readme file
 if [ $coupled != WRFint ]; then
     srun -n $cores changeDictionary -dict system/changeDictionaryDict.TVMIO -time $startTime -subDict dictionaryReplacement -parallel > log.1.changeDictionary.TVMIO 2>&1
 fi

--- a/exampleCases/tut.ABLflatTerrain.run/2_solve
+++ b/exampleCases/tut.ABLflatTerrain.run/2_solve
@@ -60,7 +60,21 @@ if [ $latestTime -lt $endTimeBeforeAvg ]; then
 fi
 
 if [ $coupled = WRFint ]; then
+    # If WRFint, then this case is acting like a WRF-driven precursor
+
     foamDictionary -entry "boundaryData.enabled"  -set "true" system/sampling/boundaryData
+    # Make the "precursor" data ready for future mapping
+    if [ -d processor0/$startTimeAvg ] && [ ! -f log.3.reconstructPar ]; then
+        foamDictionary -entry "writeFormat" -set ascii -disableFunctionEntries system/controlDict
+        reconstructPar -time $startTimeAvg -fields '(U T k p_rgh kappat nut qwall Rwall)'> log.3.reconstructPar 2>&1
+        # The z0 gets recomposed as 0, sometimes with '-nan` values. This is a known bug. Workaround below
+        z0=$(foamDictionary -entry "z0" -value setUp)
+        sed -i 's/-nan/0/g' $startTimeAvg/Rwall
+        foamDictionary -entry "boundaryField.lower.z0" -set $z0 $startTimeAvg/Rwall
+        foamDictionary -entry "writeFormat" -set binary -disableFunctionEntries system/controlDict
+    else
+        touch "WARNING_4"
+    fi
 fi
 
 # Split run to save averages
@@ -71,6 +85,16 @@ foamDictionary -entry "startTime" -set $continueTime -disableFunctionEntries sys
 foamDictionary -entry "endTime" -set $endTimeAvg -disableFunctionEntries system/controlDict 
 foamDictionary -entry "writeInterval" -set $writeIntervalAvg -disableFunctionEntries system/controlDict
 srun -n $cores --cpu_bind=cores $solver -parallel > log.2.$solver.startAt$continueTime 2>&1
+
+
+if [ $coupled = WRFint ]; then
+    # Adjust the initial time of boundaryData if it hasn't been adjusted yet
+    if [ ! -d postProcessing/boundaryData/north/$startTimeAvg ]; then
+        for dir in north south east west; do
+            ln -sf $(ls -v postProcessing/boundaryData/$dir | head -1) postProcessing/boundaryData/$dir/$startTimeAvg
+        done
+    fi
+fi
 
 echo "Ending OpenFOAM job at: " $(date)
 

--- a/exampleCases/tut.ABLflatTerrain.run/readme.md
+++ b/exampleCases/tut.ABLflatTerrain.run/readme.md
@@ -1,8 +1,10 @@
 # Instructions and general case notes
 
 - Wind plant run that uses the precursor data
+- For WRF internal coupling, this is the "precursor" case to use
+- For WRF cases, specify the correct `qwall` BC. The syntaxes are commented out on `0.forWRFcoupled/qwall.wrf`
 - A manual setup of `changeDictionaryDict` is needed depending on flow direction
-- Case relies on an appropriate precursor
+- Unless WRF internal coupled, this case relies on an appropriate precursor
 - No turbine files included
 - Adjust the refinement regions as needed. The idea of the `ground` one is that the the refinement is near the `lower` patch and consequently the `wallModelAverageType` should be modified
 - For a crashed/restarted run, just re-submit 2_solve. No changing of the script is necessary whatsoever

--- a/exampleCases/tut.ABLflatTerrain.run/setUp.wrf
+++ b/exampleCases/tut.ABLflatTerrain.run/setUp.wrf
@@ -61,6 +61,8 @@ decompOrder          (6 6 6);                     // Order of the decomposition 
 
 // Planar averaging and source term statistics options.
 // * Used by the planarAveraging function object in 'system/sampling/planarAveraging'
+writeSource                 true;
+writeSourceInterval         1;
 writePlanarAverage          true;
 writePlanarAverageInterval  1;
 

--- a/exampleCases/tut.ABLflatTerrain.run/system/blockMeshDict
+++ b/exampleCases/tut.ABLflatTerrain.run/system/blockMeshDict
@@ -140,7 +140,8 @@ boundary
     }
     west
     { 
-        type patch;
+        type cyclic;
+        neighbourPatch east;
         faces
         (
             ( 0  4  7  3)
@@ -151,7 +152,8 @@ boundary
     }
     east
     { 
-        type patch;
+        type cyclic;
+        neighbourPatch west;
         faces
         (
             ( 1  2  6  5)
@@ -162,7 +164,8 @@ boundary
     }
     north
     { 
-        type patch;
+        type cyclic;
+        neighbourPatch south;
         faces
         (
             ( 3  7  6  2)
@@ -173,7 +176,8 @@ boundary
     }
     south
     { 
-        type patch;
+        type cyclic;
+        neighbourPatch north;
         faces
         (
             ( 0  1  5  4)

--- a/exampleCases/tut.ABLflatTerrain.run/system/fvSolution
+++ b/exampleCases/tut.ABLflatTerrain.run/system/fvSolution
@@ -104,7 +104,7 @@ PIMPLE
     nCorrectors              3;
     nNonOrthogonalCorrectors 0;
     activatePressureRefCell  false;    // default: true
-    pRefPoint                (#calc "($xMax + $xMin)/2+0.001"    #calc "($yMax + $yMin)/2+0.001"    #calc "$zMin+85.001");
+    pRefPoint                (#calc "($xMax + $xMin)/2+0.001"    #calc "($yMax + $yMin)/2+0.001"    #calc "$zMax-100.001");
     pRefValue                0;
 }
 

--- a/exampleCases/tut.ABLterrain/system/fvSolution.flow
+++ b/exampleCases/tut.ABLterrain/system/fvSolution.flow
@@ -119,7 +119,7 @@ PIMPLE
     nCorrectors              3;
     nNonOrthogonalCorrectors 1;
     activatePressureRefCell  false;    // default: true
-    pRefPoint                (#calc "($xMax + $xMin)/2+0.001"    #calc "($yMax + $yMin)/2+0.001"    #calc "$zMin+85.001");
+    pRefPoint                (#calc "($xMax + $xMin)/2+0.001"    #calc "($yMax + $yMin)/2+0.001"    #calc "$zMax-100.001");
     pRefValue                0;
 }
 

--- a/src/ABLForcing/spongeLayer/spongeLayer.C
+++ b/src/ABLForcing/spongeLayer/spongeLayer.C
@@ -81,7 +81,7 @@ void Foam::spongeLayer::readSingleSpongeSubdict_(int s)
         }
         else if (patch_ == "south")
         {
-            startLocation_ = bb.min()[0];
+            startLocation_ = bb.min()[1];
             coordIndex_ = 1;
             direction_ = "stepDown";
         }


### PR DESCRIPTION
There was a minor bug on the specification of the `south` damping layer.
Also included in this PR are a few very minor tweaks to tutorial files.