### PR TITLE
Fix bug with TVMIO when `offset` is specified

### DIFF
--- a/src/boundaryConditions/inflowOutflow/timeVaryingMappedInletOutlet/README.md
+++ b/src/boundaryConditions/inflowOutflow/timeVaryingMappedInletOutlet/README.md
@@ -50,6 +50,14 @@
 - `operator=` is no longer overridden; this was a redefinition of the more general calculation in
   evaluate(), but without the "refGradient" term. In our case, refGradient is always set to zero 
   and the inherited operator= and operator== should be consistent. 
+  
+- It is important to remember that this `TVMIO` class is a child of the `mixed` boundary condition 
+  class, not the `TVMFV` class.  This code is basically a copy of `TVMFV` with the necessary 
+  changes and inheritance of `mixed` instead of `fixedValue`.  As such, it is important to remember
+  that the code should not be applying the boundary data values of quantities to the actual `value`
+  of the patch, but rather to `refVal()`.  Once `refVal` is set, `evaluate()` in the `mixed` boundary
+  condition class will compute what the patch values should be based on whether it is inflow or
+  outflow.  Therefore, when the code reads in boundary data, that data should be used to set `refValue()`.
 
 
 ## Minor changes affecting usage

--- a/src/boundaryConditions/inflowOutflow/timeVaryingMappedInletOutlet/README.md
+++ b/src/boundaryConditions/inflowOutflow/timeVaryingMappedInletOutlet/README.md
@@ -1,5 +1,13 @@
 # Changes from v2.4.x
 
+## Changelog
+
+- 2021-06-20 - fixed mysterious offset bug
+- 2020-06-03 - initial implementation in OpenFOAM-6
+
+
+## Details
+
 - Constructor from patch, internal field, and dictionary: If a value is provided in the BC dict,
   then apply operator== instead of operator= (change in OpenFOAM-6). Otherwise, call update the
   fixed values and then apply operator== instead of calling evaluate(). Evaluate() calls:

--- a/src/boundaryConditions/inflowOutflow/timeVaryingMappedInletOutlet/README.md
+++ b/src/boundaryConditions/inflowOutflow/timeVaryingMappedInletOutlet/README.md
@@ -2,7 +2,7 @@
 
 ## Changelog
 
-- 2021-06-20 - fixed mysterious offset bug
+- 2021-06-20 - fixed offset and setAverage bug
 - 2020-06-03 - initial implementation in OpenFOAM-6
 
 

--- a/src/boundaryConditions/inflowOutflow/timeVaryingMappedInletOutlet/timeVaryingMappedInletOutletFvPatchField.C
+++ b/src/boundaryConditions/inflowOutflow/timeVaryingMappedInletOutlet/timeVaryingMappedInletOutletFvPatchField.C
@@ -558,13 +558,25 @@ void Foam::timeVaryingMappedInletOutletFvPatchField<Type>::updateCoeffs()
         return;
     }
 
-    // The inletOutlet part of the update, which determines whether direction
-    // of the massflow from phi and updates the valueFraction variable
+    // The inletOutlet part of the update, which determines the direction of
+    // the massflow from phi and updates the valueFraction variable
     updateInletOutlet();
 
     // The fixedValue part of the update, closely following the updateCoeffs
     // function from timeVaryingMappedFixedValue to update the refValue variable
     updateFixedValue();
+
+    if (debug)
+    {
+        Info<< "updateCoeffs : " << this->patch().name() << " refValue"
+            << " min:" << gMin(this->refValue())
+            << " max:" << gMax(this->refValue())
+            << " avg:" << gAverage(this->refValue()) << endl;
+        Info<< "updateCoeffs : " << this->patch().name() << " valueFraction"
+            << " min:" << gMin(this->valueFraction())
+            << " max:" << gMax(this->valueFraction())
+            << " avg:" << gAverage(this->valueFraction()) << endl;
+    }
 
     // Instead of applying operator==, as is done in the timeVaryingMappedFixedValue,
     // let the field assignment take place in evaluate()
@@ -686,11 +698,19 @@ void Foam::timeVaryingMappedInletOutletFvPatchField<Type>::updateFixedValue()
     }
 
     // Apply offset to mapped values
+    //Info<< "updateFixedValue BEFORE offset: refValue min:" << gMin(this->refValue())
+    //    << " max:" << gMax(this->refValue())
+    //    << " avg:" << gAverage(this->refValue()) << endl;
     if (offset_.valid())
     {
         const scalar t = this->db().time().timeOutputValue();
         //this->operator==(*this + offset_->value(t));
-        this->refValue() = (*this + offset_->value(t));
+        //this->refValue() = (*this + offset_->value(t)); // this results in unexpected behavior!
+        this->refValue() += offset_->value(t);
+        //Info<< "updateFixedValue AFTER adding " << offset_->value(t)
+        //    << " : refValue min:" << gMin(this->refValue())
+        //    << " max:" << gMax(this->refValue())
+        //    << " avg:" << gAverage(this->refValue()) << endl;
     }
 
     if (debug)

--- a/src/boundaryConditions/inflowOutflow/timeVaryingMappedInletOutlet/timeVaryingMappedInletOutletFvPatchField.C
+++ b/src/boundaryConditions/inflowOutflow/timeVaryingMappedInletOutlet/timeVaryingMappedInletOutletFvPatchField.C
@@ -680,8 +680,7 @@ void Foam::timeVaryingMappedInletOutletFvPatchField<Type>::updateFixedValue()
                 Pout<< "updateFixedValue :"
                     << " offsetting with:" << offset << endl;
             }
-            //this->operator==(fld + offset);
-            this->refValue() = (fld + offset);
+            this->refValue() += offset;
         }
         else
         {
@@ -692,8 +691,7 @@ void Foam::timeVaryingMappedInletOutletFvPatchField<Type>::updateFixedValue()
                 Pout<< "updateFixedValue :"
                     << " scaling with:" << scale << endl;
             }
-            //this->operator==(scale*fld);
-            this->refValue() = (scale*fld);
+            this->refValue() *= scale;
         }
     }
 
@@ -704,8 +702,6 @@ void Foam::timeVaryingMappedInletOutletFvPatchField<Type>::updateFixedValue()
     if (offset_.valid())
     {
         const scalar t = this->db().time().timeOutputValue();
-        //this->operator==(*this + offset_->value(t));
-        //this->refValue() = (*this + offset_->value(t)); // this results in unexpected behavior!
         this->refValue() += offset_->value(t);
         //Info<< "updateFixedValue AFTER adding " << offset_->value(t)
         //    << " : refValue min:" << gMin(this->refValue())

--- a/src/boundaryConditions/inflowOutflow/timeVaryingMappedInletOutlet/timeVaryingMappedInletOutletFvPatchField.H
+++ b/src/boundaryConditions/inflowOutflow/timeVaryingMappedInletOutlet/timeVaryingMappedInletOutletFvPatchField.H
@@ -192,6 +192,8 @@ protected:
         Type endAverage_;
 
         //- Time varying offset values to interpolated data
+        // Note: Valid Function1 types are:
+        // ( constant csvFile one polynomial scale sine square table tableFile uniform zero )
         autoPtr<Function1<Type>> offset_;
 
         //- Helper function to find the field files


### PR DESCRIPTION
The fix is to update refValue() with offset using `+=`. SOWFA-6 results with TVMIO now appear to be consistent with SOWFA-2.4.x.

`(*this + offset_->value(t))` can give unexpected results--the entire TVM inflow plane gets wiped out--even when `offset (0 0 0)` and `offset 0` are specified for U and T, respectively.

E.g., comparison of TVMIO/TVMFV on an inflow plane:
![compare_U_westBC_versions](https://user-images.githubusercontent.com/18267059/126431709-3d238d11-718f-489f-8378-6a32de7bdfd6.png)
