### PR TITLE
Fix for Proper First Time Step Behavior of BDF2 With Multiple Outer Iterations

### DIFF
--- a/applications/solvers/superDeliciousVanilla/computeDivergence.H
+++ b/applications/solvers/superDeliciousVanilla/computeDivergence.H
@@ -1,5 +1,4 @@
 // Calculate divergence of velocity flux and display
-if (pimple.finalPimpleIter())
 {
 
     // Compute divergence cell by cell and report statistics.

--- a/applications/solvers/superDeliciousVanilla/superDeliciousVanilla.C
+++ b/applications/solvers/superDeliciousVanilla/superDeliciousVanilla.C
@@ -44,7 +44,6 @@ Description
 #include "wallDist.H"
 #include "fixedFluxPressureFvPatchScalarField.H"
 #include "timeVaryingMappedInletOutletFvPatchField.H"
-#include "interpolateXY.H"
 #include "fvOptions.H"
 #include "pimpleControl.H"
 #include "ABL.H"
@@ -88,10 +87,24 @@ int main(int argc, char *argv[])
         #include "setDeltaT.H"
         #include "updateDivSchemeBlendingField.H"
 
+        word timeNameOld = runTime.timeName();
+
         runTime++;
 
-        Info << "Time = " << runTime.timeName() << tab;
-        Info << "Time Step = " << runTime.timeIndex() << endl;
+        Info << "Time Step = " << runTime.timeIndex() << ", ";
+        Info << "Time = " << timeNameOld << " to " << runTime.timeName() << " s";
+        Info << nl << endl;
+
+        // Test to see if simulation begins without t^(n-1) (*_0) fields.
+        // Without those fields, the backward d/dt scheme reverts to Euler
+        // implicit in outer iteration 0, but uses full backward in
+        // iterations >0, and the U,T^(n-1) data is incorrect.  Outer
+        // iterations >0 are only required to achieve 2nd-order accuracy
+        // in time, but since that is not possible in the first time step
+        // without t^(n-1) data, we really only need 1 outer iteration,
+        // anyway.
+        bool limitOuterLoop = ((U.nOldTimes() == 0) || (T.nOldTimes() == 0)) ? true : false;
+
 
         // Outer-iteration loop.
         while (pimple.loop())
@@ -123,9 +136,20 @@ int main(int argc, char *argv[])
                 corrIter++;
             }
 
-            // Compute the continuity errors.
-            #include "computeDivergence.H"
+            // If starting without the t^(n-1) data, advance through the remaining
+            // outer iterations without doing anything by calling pimple.loop().
+            if (limitOuterLoop)
+            {
+                while (pimple.loop());
+                Info << endl;
+                break;
+            }
+
+            Info << endl;
         }
+
+        // Compute the continuity errors.
+        #include "computeDivergence.H"
 
         // Update timeVaryingMappedInletOutlet parameters
         #include "updateFixesValue.H"


### PR DESCRIPTION
The 2nd-order backward time-differencing (BDF2) scheme requires the t^{n-1} values of the field being advanced.  It reverts to 1st-order Euler implicit if those values are not provided, for example in the first time step of a simulation, or in the first time step of a restart without the *_0 files.  (As a side note, I learned that it is probably best to always restart with the *_0 files even when we go from precursor to inflow/outflow.) However, if >1 outer iteration is specified, BDF2 no longer reverts to Euler implicit in the 2nd and greater outer iterations and the t^{n-1} value comes from the previous outer iteration which is wrong and yields the wrong results at t^{n+1}.  This fix limits the solver to 1 outer iteration if the *_0 files are not provided.  This fix makes sense because 2 outer iterations are required to get true 2nd-order accuracy in time, and if we are reverting to 1st-order Euler implicit, then the 2nd and greater outer iterations are not of use anyway.