### PR TITLE
Updated arrayStructured and cylinder Sampling Capability

### DIFF
--- a/src/sampling/controlDict
+++ b/src/sampling/controlDict
@@ -1,0 +1,63 @@
+array
+{
+    type                sets;
+    functionObjectLibs ("libSOWFAsampling.so" "libSOWFAfileFormats.so");
+    enabled             true;
+    writeControl        timeStep;
+    writeInterval       1;
+    interpolationScheme cellPoint;      // cell, cellPoint, cellPointCell
+  //setFormat           vtkStructured;
+    setFormat           ensight;
+    fields
+    (
+      U
+    );
+
+    sets
+    (
+        // This is an example of a Cartesian structured array of sampling points
+        // with box origin corner at (-15, -50, -50) m and with x, y, z side lengths
+        // of (30, 100, 100) m.  There are 3 points in x, and 51 in y and z, so really
+        // this looks like three highly resolved y-z sampling planes.  This is useful
+        // for sampling in wind turbine wakes at different downstream locations.  This
+        // format works well with the "vtkStructured" data writer.
+        box.1
+        {
+            type               arrayStructured;
+            origin            (-15.0 -50.0 -50.0);
+            spanBox           ( 30.0 100.0 100.0);
+            pointsDensity     (3 51 51);
+            coordinateRotation
+            {
+                type           axesRotation;
+                e1            (1 0 0);
+                e2            (0 1 0);
+            }
+            axis               xyz;
+        }
+
+        // This is an example of a sampling array in polar coordinates.  The sampling
+        // cylindrical axis starts at (15, 0, 0) m and extends to (15, 0, 0) m.  The
+        // sampling only happens between radii of 25 and 50 m from the axis.  This set
+        // up is not the complete cylinder in azimuth because sampling starts at 0 degrees
+        // (in this case that radius points along +y) and ends at 270 degrees (in this case
+        // that radius points in -z).  The sampling is 31 points in the axial, 7 points
+        // in the aximuthal, and 26 points in the radial direction.  With 7 azimuthal locations
+        // this ends up looking like x-r planes every 45 degrees in the azimuth.  This
+        // is useful for axisymmetric problems like some wake situations.  This does not work
+        // with vtkStructured, so resort to another format like unstructured vtk ("vkt") or
+        // "ensight".
+        cylinder.1
+        {
+            type               cylinder;
+            axisPointStart    (-15.0 0.0 0.0);
+            axisPointEnd      ( 15.0 0.0 0.0);
+            radiusStart        25.0;
+            radiusEnd          50.0;
+            thetaStart         0.0;
+            thetaEnd          270.0;
+            pointsDensity     (31 7 26);
+            axis               xyz;
+        }
+    );
+}

--- a/src/sampling/sampledSet/arrayStructured/arrayStructured.H
+++ b/src/sampling/sampledSet/arrayStructured/arrayStructured.H
@@ -29,19 +29,28 @@ Description
 
 Usage
     \table
-        Property    | Description                            | Req'd? | Default
-        box         | The box which contains the samples     | yes    |
-        nPoints     | The number of points in each direction | yes    |
-        axis        | The coordinate axis that is written    | yes    |
+        Property           | Description                             | Req'd? | Default
+        origin             | The origin of the box                   | yes    |
+        spanBox            | The length of the box in each direction | yes    |
+        pointsDensity      | The number of points in the box         | yes    |
+        coordinateRotation | Specifies a rotation of the box         | yes    |
+        axis               | The coordinate axis that is written     | yes    |
     \endtable
 
     Example specification:
     \verbatim
     {
-        type        arrayStructured;
-        box         (0.95 0 0.25) (1.2 0.25 0.5);
-        nPoints     (2 4 6);
-        axis        x;
+        type               arrayStructured;
+        origin            (0.01 -50.01 -50.01);
+        spanBox           (0.00  100.0 100.0);
+        pointsDensity     (1 3 3);
+        coordinateRotation
+        {
+            type    axesRotation;
+            e1      (1 0 0);
+            e2      (0 1 0);
+        }
+        axis        xyz;
     }
     \endverbatim
 

--- a/src/sampling/sampledSet/cylinder/cylinderSet.H
+++ b/src/sampling/sampledSet/cylinder/cylinderSet.H
@@ -44,16 +44,14 @@ Usage
     \verbatim
     {
         type               cylinder;
-        origin            (0.01 -50.01 -50.01);
-        spanBox           (0.00  100.0 100.0);
-        pointsDensity     (1 3 3);
-        coordinateRotation
-        {
-            type    axesRotation;
-            e1      (1 0 0);
-            e2      (0 1 0);
-        }
-        axis        xyz;
+        axisPointStart    (-15.0 0.0 0.0);
+        axisPointEnd      ( 15.0 0.0 0.0);
+        radiusStart        25.0;
+        radiusEnd          50.0;
+        thetaStart         0.0;
+        thetaEnd          270.0;
+        pointsDensity     (31 7 26);
+        axis               xyz;
     }
     \endverbatim
 

--- a/src/sampling/sampledSet/cylinder/cylinderSet.H
+++ b/src/sampling/sampledSet/cylinder/cylinderSet.H
@@ -25,7 +25,37 @@ Class
     Foam::cylinderSet
 
 Description
-    Samples a regular array of points on a cylinder
+    Samples a regular array of points on a cylinder.
+
+Usage
+    \table
+        Property           | Description                             | Req'd? | Default
+        axisPointStart     | The starting point of the cylinder axis | yes    |
+        axisPointEnd       | The ending point of the cylinder axis   | yes    |
+        radiusStart        | The starting radius of the cylinder     | yes    |
+        radiusEnd          | The ending radius of the cylinder       | yes    |
+        thetaStart         | The starting azimuth (in degrees)       | yes    |
+        thetaEnd           | The ending azimuth (in degrees)         | yes    |
+        pointsDensity      | The number of points in the box         | yes    |
+        axis               | The coordinate axis that is written     | yes    |
+    \endtable
+
+    Example specification:
+    \verbatim
+    {
+        type               cylinder;
+        origin            (0.01 -50.01 -50.01);
+        spanBox           (0.00  100.0 100.0);
+        pointsDensity     (1 3 3);
+        coordinateRotation
+        {
+            type    axesRotation;
+            e1      (1 0 0);
+            e2      (0 1 0);
+        }
+        axis        xyz;
+    }
+    \endverbatim
 
 SourceFiles
     cylinderSet.C
@@ -36,6 +66,7 @@ SourceFiles
 #define cylinderSet_H
 
 #include "sampledSet.H"
+#include "labelVector.H"
 #include "DynamicList.H"
 #include "coordinateSystem.H"
 
@@ -44,9 +75,8 @@ SourceFiles
 namespace Foam
 {
 
-// Forward declaration of classes
-class passiveParticle;
-template<class Type> class particle;
+namespace sampledSets
+{
 
 /*---------------------------------------------------------------------------*\
                            Class cylinderSet Declaration
@@ -59,15 +89,20 @@ class cylinderSet
     // Private data
 
         //- Origin (x, y, z) in global cartesian co-ordinates
-        point origin1_;
-        point origin2_;
+        point axisPointStart_;
+        point axisPointEnd_;
 
         //- Radius of cylinder
-        scalar radius_;
+        scalar radiusStart_;
+        scalar radiusEnd_;
 
-        //- Number of axial and azimuthal sampling points
-        scalar dAxial_;
-        scalar dAzimuthal_;
+        //- Azimuth start and end locations in degrees and radians.
+        scalar thetaStartDeg_;
+        scalar thetaEndDeg_;
+
+        //- Number of points in each direction.
+        labelVector pointsDensity_;
+
 
 
     // Private Member Functions
@@ -101,11 +136,13 @@ public:
             const polyMesh& mesh,
             const meshSearch& searchEngine,
             const word& axis,
-            const point& origin1,
-            const point& origin2,
-            const scalar& radius,
-            const scalar& dAxial,
-            const scalar& dAzimuthal
+            const point& axisPointStart,
+            const point& axisPointEnd,
+            const scalar& radiusStart,
+            const scalar& radiusEnd,
+            const scalar& thetaStart,
+            const scalar& thetaEnd,
+            const labelVector& pointsDensity
         );
 
         //- Construct from dictionary
@@ -125,6 +162,7 @@ public:
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
+} // End namespace sampledSets
 } // End namespace Foam
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //


### PR DESCRIPTION
Updated arrayStructured to fix problem where points written out in a scrambled fashion--now writeout remains in proper i,j,k structured order.  This means that arrayStructured can now be used with vtkStructuredWriter without issue. Updated cylinder capability for far greater flexibility.  Both now have a feature that breaks ties for points on cell faces on processor boundaries so that a single sample point is not claimed by more than one processor.